### PR TITLE
Throw an error if the Key ARN is not set

### DIFF
--- a/kmssigner/signer.go
+++ b/kmssigner/signer.go
@@ -44,6 +44,11 @@ func New(kmsapi *kms.KMS, keyArn string) (crypto.Signer, error) {
 		"kmssigner.kms.key_arn": keyArn,
 	})
 
+	if len(keyArn) == 0 {
+		l.Warn("The provided keyArn is empty!")
+		return nil, fmt.Errorf("hallow/kmssigner: keyArn is an empty string")
+	}
+
 	pubKeyResponse, err := kmsapi.GetPublicKeyWithContext(
 		context.TODO(),
 		&kms.GetPublicKeyInput{


### PR DESCRIPTION
```
[paultag@nyx:~/dev/local/hallow][12:03 AM] ♥  go run *.go
WARN[0000] The provided keyArn is empty!                 kmssigner.kms.key_arn=
panic: hallow/kmssigner: keyArn is an empty string

goroutine 1 [running]:
main.main()
	/home/paultag/dev/local/hallow/main.go:180 +0x283
exit status 2
```