### PR TITLE
close open fds after writing

### DIFF
--- a/cmd/hallow-cli/sign.go
+++ b/cmd/hallow-cli/sign.go
@@ -77,8 +77,10 @@ func Sign(c *cli.Context) error {
 		_, err = fd.Write(ssh.MarshalAuthorizedKey(pubKey))
 		if err != nil {
 			l.WithFields(log.Fields{"error": err}).Warn("failed to write cert to open file")
+			fd.Close()
 			return err
 		}
+		fd.Close()
 		l.Debug("Successfully wrote Certificate out")
 	}
 


### PR DESCRIPTION
the "root cause" of this issue is that I'm not using defer, but since we're in a loop we won't close open fds until we finish processing all files. We could refactor it into a function invocation per file, but I didn't have that particular impulse.