### PR TITLE
Add support for SSH Agent

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -3,7 +3,8 @@ package client
 import (
 	"context"
 	"crypto"
-	"crypto/ed25519"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
@@ -60,13 +61,13 @@ func (c Client) GenerateAndRequestCertificate(
 	l := log.WithFields(log.Fields{
 		"hallow.public_key.comment": comment,
 	})
-	pubKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
 		l.WithFields(log.Fields{"error": err}).Fatal("Can't generate key")
 		return nil, nil, err
 	}
 
-	sshPubKey, err := ssh.NewPublicKey(pubKey)
+	sshPubKey, err := ssh.NewPublicKey(privateKey.Public())
 	if err != nil {
 		l.WithFields(log.Fields{"error": err}).Fatal("Can't create ssh Public Key")
 		return nil, nil, err

--- a/client/client.go
+++ b/client/client.go
@@ -3,8 +3,6 @@ package client
 import (
 	"context"
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
@@ -56,18 +54,20 @@ func keyToString(pubKey ssh.PublicKey, comment string) string {
 // any error conditions that were hit during execution.
 func (c Client) GenerateAndRequestCertificate(
 	ctx context.Context,
+	keyType KeyType,
 	comment string,
 ) (crypto.Signer, ssh.PublicKey, error) {
 	l := log.WithFields(log.Fields{
 		"hallow.public_key.comment": comment,
 	})
-	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+
+	privKey, pubKey, err := generateKey(rand.Reader, keyType)
 	if err != nil {
 		l.WithFields(log.Fields{"error": err}).Fatal("Can't generate key")
 		return nil, nil, err
 	}
 
-	sshPubKey, err := ssh.NewPublicKey(privateKey.Public())
+	sshPubKey, err := ssh.NewPublicKey(pubKey)
 	if err != nil {
 		l.WithFields(log.Fields{"error": err}).Fatal("Can't create ssh Public Key")
 		return nil, nil, err
@@ -85,7 +85,7 @@ func (c Client) GenerateAndRequestCertificate(
 		return nil, nil, err
 	}
 
-	return privateKey, sshPubKey, nil
+	return privKey, sshPubKey, nil
 
 }
 

--- a/client/generate.go
+++ b/client/generate.go
@@ -35,8 +35,6 @@ func generateKey(rand io.Reader, keyType KeyType) (crypto.Signer, crypto.PublicK
 			curve = elliptic.P384()
 		case KeyTypeECDSAP521:
 			curve = elliptic.P521()
-		default:
-			return nil, nil, fmt.Errorf("hallow/client: unknown ecdsa curve")
 		}
 		privKey, err := ecdsa.GenerateKey(curve, rand)
 		if err != nil {
@@ -50,8 +48,6 @@ func generateKey(rand io.Reader, keyType KeyType) (crypto.Signer, crypto.PublicK
 			size = 2048
 		case KeyTypeRSA4096:
 			size = 4096
-		default:
-			return nil, nil, fmt.Errorf("hallow/client: unknown rsa size")
 		}
 		privKey, err := rsa.GenerateKey(rand, size)
 		if err != nil {

--- a/client/generate.go
+++ b/client/generate.go
@@ -1,0 +1,70 @@
+package client
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"fmt"
+	"io"
+)
+
+type KeyType uint8
+
+const (
+	KeyTypeECDSAP224 KeyType = iota
+	KeyTypeECDSAP256
+	KeyTypeECDSAP384
+	KeyTypeECDSAP521
+	KeyTypeED25519
+	KeyTypeRSA2048
+	KeyTypeRSA4096
+)
+
+// Generate a key of the given Key Type.
+//
+//
+func generateKey(rand io.Reader, keyType KeyType) (crypto.Signer, crypto.PublicKey, error) {
+	switch keyType {
+	case KeyTypeECDSAP224, KeyTypeECDSAP256, KeyTypeECDSAP384, KeyTypeECDSAP521:
+		var curve elliptic.Curve
+		switch keyType {
+		case KeyTypeECDSAP224:
+			curve = elliptic.P224()
+		case KeyTypeECDSAP256:
+			curve = elliptic.P256()
+		case KeyTypeECDSAP384:
+			curve = elliptic.P384()
+		case KeyTypeECDSAP521:
+			curve = elliptic.P521()
+		default:
+			return nil, nil, fmt.Errorf("hallow/client: unknown ecdsa curve")
+		}
+		privKey, err := ecdsa.GenerateKey(curve, rand)
+		if err != nil {
+			return nil, nil, err
+		}
+		return privKey, privKey.Public(), nil
+	case KeyTypeRSA2048, KeyTypeRSA4096:
+		var size int = 0
+		switch keyType {
+		case KeyTypeRSA2048:
+			size = 2048
+		case KeyTypeRSA4096:
+			size = 4096
+		default:
+			return nil, nil, fmt.Errorf("hallow/client: unknown rsa size")
+		}
+		privKey, err := rsa.GenerateKey(rand, size)
+		if err != nil {
+			return nil, nil, err
+		}
+		return privKey, privKey.Public(), nil
+	case KeyTypeED25519:
+		pubKey, privKey, err := ed25519.GenerateKey(rand)
+		return privKey, pubKey, err
+	default:
+		return nil, nil, fmt.Errorf("hallow/client: unknown key type: %x", keyType)
+	}
+}

--- a/client/generate.go
+++ b/client/generate.go
@@ -13,8 +13,7 @@ import (
 type KeyType uint8
 
 const (
-	KeyTypeECDSAP224 KeyType = iota
-	KeyTypeECDSAP256
+	KeyTypeECDSAP256 KeyType = iota
 	KeyTypeECDSAP384
 	KeyTypeECDSAP521
 	KeyTypeED25519
@@ -27,11 +26,9 @@ const (
 //
 func generateKey(rand io.Reader, keyType KeyType) (crypto.Signer, crypto.PublicKey, error) {
 	switch keyType {
-	case KeyTypeECDSAP224, KeyTypeECDSAP256, KeyTypeECDSAP384, KeyTypeECDSAP521:
+	case KeyTypeECDSAP256, KeyTypeECDSAP384, KeyTypeECDSAP521:
 		var curve elliptic.Curve
 		switch keyType {
-		case KeyTypeECDSAP224:
-			curve = elliptic.P224()
 		case KeyTypeECDSAP256:
 			curve = elliptic.P256()
 		case KeyTypeECDSAP384:

--- a/cmd/hallow-cli/agent.go
+++ b/cmd/hallow-cli/agent.go
@@ -29,13 +29,8 @@ var (
 			},
 			&cli.StringFlag{
 				Name:  "key-type",
-				Usage: "Key type to generate [ecdsa|ed25519]",
-				Value: "ecdsa",
-			},
-			&cli.IntFlag{
-				Name:  "key-bits",
-				Usage: "for ecdsa, this will select curve sizes [256|384|521]",
-				Value: 384,
+				Usage: "Key type to generate [ecdsa256|ecdsa384|ecdsa521|ed25519]",
+				Value: "ecdsa384",
 			},
 		},
 	}

--- a/cmd/hallow-cli/agent.go
+++ b/cmd/hallow-cli/agent.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	log "github.com/sirupsen/logrus"
+	"net"
+	"os"
+
+	"github.com/urfave/cli/v2"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+var (
+	AgentCommand = &cli.Command{
+		Name:   "ssh-add",
+		Usage:  "Generate a new ssh key, and add the key and certificate to an agent",
+		Action: Agent,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "comment",
+				Value: "hallow",
+			},
+			&cli.StringFlag{
+				Name:    "ssh-auth-sock",
+				EnvVars: []string{"SSH_AUTH_SOCK"},
+				Value:   "",
+			},
+		},
+	}
+)
+
+//
+func Agent(c *cli.Context) error {
+	hallow := hallowClientFromCLI(c)
+	_ = hallow
+
+	socket := os.Getenv("SSH_AUTH_SOCK")
+	conn, err := net.Dial("unix", socket)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"ssh_auth_sock": socket,
+			"error":         err,
+		}).Warn("failed to open SSH_AUTH_SOCK")
+		return err
+	}
+
+	agentClient := agent.NewClient(conn)
+
+	comment := c.String("comment")
+
+	privKey, pubKey, err := hallow.GenerateAndRequestCertificate(
+		c.Context,
+		comment,
+	)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Warn("failed to request Certificate")
+		return err
+	}
+	log.Debug("Certificate was signed by Hallow")
+
+	cert := pubKey.(*ssh.Certificate)
+
+	if err := agentClient.Add(agent.AddedKey{
+		PrivateKey:  privKey,
+		Certificate: cert,
+		Comment:     comment,
+	}); err != nil {
+		log.WithFields(log.Fields{
+			"ssh_auth_sock": socket,
+			"error":         err,
+		}).Warn("failed to add Certifciate to agent")
+		return err
+	}
+
+	return nil
+}

--- a/cmd/hallow-cli/main.go
+++ b/cmd/hallow-cli/main.go
@@ -20,32 +20,16 @@ func hallowClientFromCLI(c *cli.Context) client.Client {
 //
 func keyTypeFromCLI(c *cli.Context) (client.KeyType, error) {
 	switch c.String("key-type") {
-	case "ecdsa":
-		switch c.Int("key-bits") {
-		case 0:
-			return 0, fmt.Errorf("hallow-cli: must provide bit length for ecdsa keys")
-		case 256:
-			return client.KeyTypeECDSAP256, nil
-		case 384:
-			return client.KeyTypeECDSAP384, nil
-		case 521:
-			return client.KeyTypeECDSAP521, nil
-		default:
-			return 0, fmt.Errorf("hallow-cli: unknown ecdsa bit argument")
-		}
-	case "rsa":
-		switch c.Int("key-bits") {
-		case 0:
-			return 0, fmt.Errorf("hallow-cli: must provide bit length for rsa keys")
-		case 1024:
-			return 0, fmt.Errorf("hallow-cli: rsa bit size is too small")
-		case 2048:
-			return client.KeyTypeRSA2048, nil
-		case 4096:
-			return client.KeyTypeRSA4096, nil
-		default:
-			return 0, fmt.Errorf("hallow-cli: unknown rsa bit argument")
-		}
+	case "ecdsa256":
+		return client.KeyTypeECDSAP256, nil
+	case "ecdsa384":
+		return client.KeyTypeECDSAP384, nil
+	case "ecdsa521":
+		return client.KeyTypeECDSAP521, nil
+	case "rsa2048":
+		return client.KeyTypeRSA2048, nil
+	case "rsa4096":
+		return client.KeyTypeRSA4096, nil
 	case "ed25519":
 		return client.KeyTypeED25519, nil
 	default:

--- a/cmd/hallow-cli/main.go
+++ b/cmd/hallow-cli/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
@@ -14,6 +15,44 @@ import (
 //
 func hallowClientFromCLI(c *cli.Context) client.Client {
 	return client.New(session.New(), http.DefaultClient, c.String("endpoint"))
+}
+
+//
+func keyTypeFromCLI(c *cli.Context) (client.KeyType, error) {
+	switch c.String("key-type") {
+	case "ecdsa":
+		switch c.Int("key-bits") {
+		case 0:
+			return 0, fmt.Errorf("hallow-cli: must provide bit length for ecdsa keys")
+		case 224:
+			return client.KeyTypeECDSAP224, nil
+		case 256:
+			return client.KeyTypeECDSAP256, nil
+		case 384:
+			return client.KeyTypeECDSAP384, nil
+		case 521:
+			return client.KeyTypeECDSAP521, nil
+		default:
+			return 0, fmt.Errorf("hallow-cli: unknown ecdsa bit argument")
+		}
+	case "rsa":
+		switch c.Int("key-bits") {
+		case 0:
+			return 0, fmt.Errorf("hallow-cli: must provide bit length for rsa keys")
+		case 1024:
+			return 0, fmt.Errorf("hallow-cli: rsa bit size is too small")
+		case 2048:
+			return client.KeyTypeRSA2048, nil
+		case 4096:
+			return client.KeyTypeRSA4096, nil
+		default:
+			return 0, fmt.Errorf("hallow-cli: unknown rsa bit argument")
+		}
+	case "ed25519":
+		return client.KeyTypeED25519, nil
+	default:
+		return 0, fmt.Errorf("hallow-cli: unknown key type")
+	}
 }
 
 func main() {

--- a/cmd/hallow-cli/main.go
+++ b/cmd/hallow-cli/main.go
@@ -44,6 +44,7 @@ func main() {
 			SignCommand,
 			GetPubKeyCommand,
 			SSHCommand,
+			AgentCommand,
 		},
 	}
 	if err := app.Run(os.Args); err != nil {

--- a/cmd/hallow-cli/main.go
+++ b/cmd/hallow-cli/main.go
@@ -24,8 +24,6 @@ func keyTypeFromCLI(c *cli.Context) (client.KeyType, error) {
 		switch c.Int("key-bits") {
 		case 0:
 			return 0, fmt.Errorf("hallow-cli: must provide bit length for ecdsa keys")
-		case 224:
-			return client.KeyTypeECDSAP224, nil
 		case 256:
 			return client.KeyTypeECDSAP256, nil
 		case 384:

--- a/cmd/hallow-cli/ssh.go
+++ b/cmd/hallow-cli/ssh.go
@@ -23,7 +23,11 @@ func SSH(c *cli.Context) error {
 
 	hallow := hallowClientFromCLI(c)
 
-	signer, sshCert, err := hallow.GenerateAndRequestCertificate(c.Context, "")
+	signer, sshCert, err := hallow.GenerateAndRequestCertificate(
+		c.Context,
+		client.KeyTypeED25519,
+		"",
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adding a key this way requires no changes to .ssh/config, only a running ssh-agent, which reduces a lot of the client setup burden. 