### PR TITLE
Add in an extension to store the endpoint.

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,6 +82,15 @@ func (c *config) handleRequest(ctx context.Context, event events.APIGatewayProxy
 		}, nil
 	}
 
+	host, ok := event.Headers["Host"]
+	if !ok {
+		log.Warn("Host header is not present!")
+		return events.APIGatewayProxyResponse{
+			Body:       "Malformed request",
+			StatusCode: 400,
+		}, nil
+	}
+
 	principal, err := createPrincipalName(userArn)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Warn("Incoming ARN isn't a valid principal")
@@ -137,10 +146,11 @@ func (c *config) handleRequest(ctx context.Context, event events.APIGatewayProxy
 		Permissions: ssh.Permissions{
 			CriticalOptions: map[string]string{},
 			Extensions: map[string]string{
-				"permit-agent-forwarding": "",
-				"permit-port-forwarding":  "",
-				"permit-pty":              "",
-				"permit-user-rc":          "",
+				"permit-agent-forwarding":  "",
+				"permit-port-forwarding":   "",
+				"permit-pty":               "",
+				"permit-user-rc":           "",
+				"hallow-host@dc.cant.vote": host,
 			},
 		},
 	}


### PR DESCRIPTION
custom extensions need to be postfix'ed with a global namespace (domain name). Usually it's the author or company -- but seeing as how it didn't seem right to set it to `@pault.ag` or `@paultag.dev` or something, I used a neutral domain of mine.

Think of it like a protest plate for cypherpunks.

But seriously, if you have better ideas on domains (I'd even be open to registering one if you think that's useful), or decide on a migration plan to change that key, I'd be open to that of course.