### PR TITLE
Static build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ clean:
 	rm -vf hallow.zip hallow
 
 hallow: *.go
-	go build -o hallow .
+	CGO_ENABLED=0 go build -o hallow .
 
 hallow.zip: hallow
 	zip hallow.zip hallow


### PR DESCRIPTION
Either disable CGO? Or can use something like:
```
go build -a -tags netgo -ldflags '-w -extldflags "-static"' .
```
to obtain full-static goodness.