### PR TITLE
Remove New() function for CA

### DIFF
--- a/ca.go
+++ b/ca.go
@@ -49,19 +49,6 @@ func (s CA) SignAndParse(template ssh.Certificate) (ssh.PublicKey, []byte, error
 	return pubKey, bytes, nil
 }
 
-// Create a new SSH Certificate Authority to sign ssh public keys.
-func New(rand io.Reader, priv crypto.Signer) (*CA, error) {
-	signer, err := ssh.NewSignerFromSigner(priv)
-	if err != nil {
-		return nil, err
-	}
-
-	return &CA{
-		Rand:   rand,
-		Signer: signer,
-	}, nil
-}
-
 // Create a Certificate. This signature looks similar to the
 // x509.CreateCertificate signature for ease of use.
 func CreateCertificate(

--- a/ca.go
+++ b/ca.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto"
 	"io"
 
 	"golang.org/x/crypto/ssh"


### PR DESCRIPTION
It wasn't being used anywhere, since the type was straight-forwardly instantiable