### PR TITLE
Apply style fixes

### DIFF
--- a/ca.go
+++ b/ca.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// Implementation of the OpenSSH Certificate Authority.
+// CA is an implementation of the OpenSSH Certificate Authority.
 //
 // This encapsulates the signing code, as well as the RNG source to be used
 // for signing operations. This contains no logic regarding certificate policy
@@ -35,7 +35,8 @@ func (s CA) Sign(template ssh.Certificate) ([]byte, error) {
 	)
 }
 
-//
+// SignAndParse will invoke the ca.Sign method, then parse the Certificate
+// back into an ssh.PublicKey.
 func (s CA) SignAndParse(template ssh.Certificate) (ssh.PublicKey, []byte, error) {
 	bytes, err := s.Sign(template)
 	if err != nil {
@@ -48,8 +49,8 @@ func (s CA) SignAndParse(template ssh.Certificate) (ssh.PublicKey, []byte, error
 	return pubKey, bytes, nil
 }
 
-// Create a Certificate. This signature looks similar to the
-// x509.CreateCertificate signature for ease of use.
+// CreateCertificate will create an SSH Certificate with an API that looks
+// similar to the x509.CreateCertificate signature for ease of use.
 func CreateCertificate(
 	rand io.Reader,
 	template ssh.Certificate,

--- a/hallow_test.go
+++ b/hallow_test.go
@@ -29,19 +29,19 @@ func TestCreatePrincipalName(t *testing.T) {
 		},
 		{
 			arn:         "arn:aws:sts::12345:federated-user/john-doe",
-			expectedErr: unsupportedStsResourceTypeError,
+			expectedErr: errUnsupportedStsResourceType,
 		},
 		{
 			arn:         "arn:aws:rds:us-east-1:12345:db:database",
-			expectedErr: unknowUserArnServiceError,
+			expectedErr: errUnknowUserArnService,
 		},
 		{
 			arn:         "arn:aws:sts::12345:assumed-role/",
-			expectedErr: malformedAssumedRoleArnError,
+			expectedErr: errMalformedAssumedRoleArn,
 		},
 		{
 			arn:         "arn:aws:sts::12345:",
-			expectedErr: unsupportedStsResourceTypeError,
+			expectedErr: errUnsupportedStsResourceType,
 		},
 	} {
 		t.Run(c.arn, func(t *testing.T) {
@@ -79,12 +79,12 @@ func TestValidatePublicKey(t *testing.T) {
 		// DSA key
 		{
 			pubKey:      "ssh-dss AAAAB3NzaC1kc3MAAACBANLlxcoOBh5rcRm3b0hg7kN31pFFesd4rAncMPe230bNabgjqCEblZPyCkqP9D4aktKIqiCk43YjreXkDrB/1a1ST0ZjGu4914eGIW68W1vCtqOqFe21kHWLhh/HhZXlWHLwrHu9RkcMOAghDhj/tlkmgu09WfTnJnuXKqrAIYmnAAAAFQCJjFbwiJP976BeSCX3tNLFzR5JHwAAAIEArAdfNtpmnThMD6guamSKg17vv1MtFCxg7xuP7kweFPFepzD+l/xKXsUq1nnTRFqF4HDsHT0xgXY5567wBfQEqATFBxY7Zd/8298TY8aQbLcjLr+pQ9bQRMjKM2XOjVr31neNSJf51DaCjmvNWMv5vnCBoIDXY72TJvSryIN/W9MAAACAFrPrlKRD746a/Qr0+ZOyUI4GJC0e04zgG9a/tLNh6cNyBn6nVVgyCOLhQqONyhZks4ZUFTHphNpEUGBUgN8Ox4kaYf4wQB6G+SvcprjZrC06RCQGJYS5vFSgNpqrh/6nCAaeDtsFH3Lx5ot/sxQYw2OzTOdkbSRCBV/SNBruDNI=",
-			expectedErr: unknownKeyTypeError,
+			expectedErr: errUnknownKeyType,
 		},
 		// Small RSA key
 		{
 			pubKey:      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQC5OXmDKEHLVj7nTnYlO5dOdK0BO1XJasLSaz9H+Psj/V3DZeQyJZFkJzyByQXOZa7DN+WEkqaapFb7ttS90Bb+zQ5raeCl3GiRmAH8peHPiOn3Sp5G9QtLFNlYuVswdzYdONX0NTIhF//L7+fmL83fr6WzdnXKL8iSsxSCBKKS5Q==",
-			expectedErr: smallRsaKeyError,
+			expectedErr: errSmallRsaKey,
 		},
 	} {
 		t.Run(c.pubKey, func(t *testing.T) {


### PR DESCRIPTION
 * errors take the form of errFoo, not fooError
 * exported methods/structs get comments like // ${Name}$ ...