### PR TITLE
No longer try to be clever in our dependabot config - it doesn't work

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,6 @@
 version: 2
 updates:
-  # Update all go deps daily, except github.com/aws/aws-sdk-go which we update
-  # weekly.
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: daily
-    ignore:
-      - dependency-name: github.com/aws/aws-sdk-go
-
-  - package-ecosystem: gomod
-    directory: "/"
-    schedule:
-      interval: weekly
-    allow:
-      - dependency-name: github.com/aws/aws-sdk-go


### PR DESCRIPTION
`The property '#/updates/1' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'`