### PR TITLE
Make Quickstart TrustedUserCAKeys Setup Clearer

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -128,7 +128,7 @@ Write the key from `hallow-ca.pub` to `/etc/ssh/hallow_cas` on the remote
 machine.
 
 ```
-$ sudo echo "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFvuBGdFLPNRg+xZkGfQ5u9V3FD6etx0cz0fx6HkjzAvZ0W/FF4HYZPsCkLpsJhjaRfF1Nm9mNXiyaHsrkfaKgQ=" > /etc/ssh/hallow_cas
+$ echo "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFvuBGdFLPNRg+xZkGfQ5u9V3FD6etx0cz0fx6HkjzAvZ0W/FF4HYZPsCkLpsJhjaRfF1Nm9mNXiyaHsrkfaKgQ=" | sudo tee /etc/ssh/hallow_cas
 ```
 
 Now, let's write out the AWS ARNs as the authorized principals for any

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -124,8 +124,12 @@ TrustedUserCAKeys=/etc/ssh/hallow_cas
 AuthorizedPrincipalsFile=/etc/ssh/principals/%u
 ```
 
-Write the key from `hallow-ca.pub` into `/etc/ssh/hallow_cas` on the remote
+Write the key from `hallow-ca.pub` to `/etc/ssh/hallow_cas` on the remote
 machine.
+
+```
+$ sudo echo "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFvuBGdFLPNRg+xZkGfQ5u9V3FD6etx0cz0fx6HkjzAvZ0W/FF4HYZPsCkLpsJhjaRfF1Nm9mNXiyaHsrkfaKgQ=" > /etc/ssh/hallow_cas
+```
 
 Now, let's write out the AWS ARNs as the authorized principals for any
 users we would like to grant access to:


### PR DESCRIPTION
I wasted a few hours because I thought `/etc/ssh/hallow_cas` was a directory that was supposed to contain a filed called `hallow-ca.pub` with our pubkey. The result was ssh auth was failing in a very non-transparent way.

After increasing sshd log verbosity to max level, studying the sshd error messages, and finally lining them up with sshd C source code, I realized `TrustedUserCAKeys` is supposed to be a regular file. Would be cool if sshd warned you about this but alas. Figured I would pay it forward so the next person does not have to go through this experience :)