### PR TITLE
Correcting docs, which give wrong principal

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -90,14 +90,13 @@ computer, so please be sure it's not important!
 
 #### Get our Principal Name
 
-First, let's figure out who the heck we are. We'll ask AWS who they think
-we are, to figure out who Hallow will think we are. Keep a note of this ARN,
-this will be used to configure the SSH daemon.
+To find the principal of the certificate, inspect the generated certificate with ssh-keygen. This can be done with the following command-line:
 
 ```
-$ aws sts get-caller-identity --query="Arn"
-"arn:aws:iam::.......:root"
+$ ssh-add -L | ssh-keygen -L -f - | grep -A1 Principals | tail -1 | sed 's/^ *//'
 ```
+
+This will be pasted in the user's principal file later.
 
 #### Remind ourselves of the SSH CA Public Key
 


### PR DESCRIPTION
The output from the AWS query to pull principal is wrong (at least in my situation, with assumed roles). The hallow-cli ssh-add doesn't include the account username in the principal, so principal lookups always fail on the remote host. Since the certificate already has the principal written to it, I added a quick one-liner instead of the aws query.